### PR TITLE
fix Class "Title" not found

### DIFF
--- a/includes/PrivateDomainsHooks.php
+++ b/includes/PrivateDomainsHooks.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\Title\Title;
 use MediaWiki\Hook\AlternateEditHook;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserGroupManager;

--- a/includes/SpecialPrivateDomains.php
+++ b/includes/SpecialPrivateDomains.php
@@ -11,6 +11,7 @@
  * @license GPL-2.0-or-later
  */
 
+use MediaWiki\Title\Title;
 use MediaWiki\MediaWikiServices;
 
 /**


### PR DESCRIPTION
引入 MediaWiki\Title\Title,以适配新版的mediawiki